### PR TITLE
Update printer-seemecnc-rostock-max-v2-2015.cfg to include the [displ…

### DIFF
--- a/config/printer-seemecnc-rostock-max-v2-2015.cfg
+++ b/config/printer-seemecnc-rostock-max-v2-2015.cfg
@@ -92,3 +92,25 @@ pins:
 
 [static_digital_output yellow_led]
 pins: !PB7
+
+[display]
+lcd_type: hd44780
+rs_pin: EXP1_4
+e_pin: EXP1_3
+d4_pin: EXP1_5
+d5_pin: EXP1_6
+d6_pin: EXP1_7
+d7_pin: EXP1_8
+encoder_pins: ^EXP2_3, ^EXP2_5
+click_pin: ^!EXP1_2
+#kill_pin: ^!EXP2_8
+
+[board_pins]
+aliases:
+    # Common EXP1/EXP2 headers found on RAMBo v1.4
+    EXP1_1=PE6, EXP1_3=PG3, EXP1_5=PJ2, EXP1_7=PJ7, EXP1_9=<GND>,
+    EXP1_2=PE2, EXP1_4=PG4, EXP1_6=PJ3, EXP1_8=PJ4, EXP1_10=<5V>,
+    # EXP2 header
+    EXP2_1=PB3, EXP2_3=PJ5, EXP2_5=PJ6, EXP2_7=PD4, EXP2_9=<GND>,
+    EXP2_2=PB1, EXP2_4=PB0, EXP2_6=PB2, EXP2_8=PE7, EXP2_10=PH2
+    # Pins EXP2_1, EXP2_6, EXP2_2 are also MISO, MOSI, SCK of bus "spi"


### PR DESCRIPTION
…ay] and [board_pins] sections needed for Reprap 20x4 LCD display

Addition of the necessary pin aliases and the [display] def in order to make the standard 20x4 display work on Rostock V2 Max printer.

Signed-off-by: Angelo Lagis angelo_lagis@hotmail.com